### PR TITLE
Allow caching spark tarball locally

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,11 @@ spark_master_port: 7077
 spark_slaves: []
 spark_user: "{% if is_integration_test is defined and is_integration_test %}kitchen{% else %}spark{% endif %}"
 spark_tgz_filename: spark-{{spark_version}}-bin-{{spark_hadoop_version}}.tgz
+# Set this directory to download and cache tarball onto local machine,
+# for when the network connection between local and host is faster
+# than between host and internet, and if role will be run for several
+# hosts.
+# spark_local_download_cache: .
 spark_tgz_url_base: http://d3kbcqa49mib13.cloudfront.net/
 spark_tgz_url: "{{spark_tgz_url_base}}{{spark_tgz_filename}}"
 spark_install_chdir: /opt

--- a/tasks/untar_spark.yml
+++ b/tasks/untar_spark.yml
@@ -3,6 +3,18 @@
   stat: path={{spark_install_dir}}
   register: install
 
+- name: Download spark on local
+  when: spark_local_download_cache is defined
+  local_action: command wget -O {{spark_local_download_cache}}/{{spark_tgz_filename}} {{spark_tgz_url}}
+  args:
+    creates: "{{spark_local_download_cache}}/{{spark_tgz_filename}}"
+
+- name: Copy from local to host
+  when: spark_local_download_cache is defined
+  copy:
+    src: "{{spark_local_download_cache}}/{{spark_tgz_filename}}"
+    dest: /tmp/{{spark_tgz_filename}}
+
 - name: Download spark
   command: wget -O /tmp/{{spark_tgz_filename}} {{spark_tgz_url}}
   args:


### PR DESCRIPTION
in the case where we are push deploying this role to multiple hosts,
and the connection between local and the hosts is better than between
the hosts and the internet.